### PR TITLE
Changes due to upcoming changes in R/qtl

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,5 +6,6 @@ Author: Konrad Zych <k.zych@rug.nl> and Danny Arends <danny.arends@gmail.com>
 Maintainer: Konrad Zych <k.zych@rug.nl>
 Description: High-throughput generation of genetic markers from molecular phenotypes for crosses between inbred strains. These markers can be use to saturate existing genetic map or creating a new one.
 Depends: R (>= 2.14.1), graphics, stats, utils, qtl, VGAM, mixtools
+Imports: grDevices
 Suggests: RankProd
 License: GPL-3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pheno2geno
-Version: 1.3.1
-Date: 2015-03-25
+Version: 1.3.2
+Date: 2017-09-12
 Title: High-Throughput Generation of Genetic Markers and Maps from Molecular Phenotypes for Crosses Between Inbred Strains
-Author: Konrad Zych <k.zych@rug.nl> and Danny Arends <danny.arends@gmail.com> 
+Author: Konrad Zych <k.zych@rug.nl> and Danny Arends <danny.arends@gmail.com>
 Maintainer: Konrad Zych <k.zych@rug.nl>
 Description: High-throughput generation of genetic markers from molecular phenotypes for crosses between inbred strains. These markers can be use to saturate existing genetic map or creating a new one.
 Depends: R (>= 2.14.1), graphics, stats, utils, qtl, VGAM, mixtools

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -13,5 +13,8 @@ import(
   VGAM
 )
 
+# import rgb from grDevices
+importFrom("grDevices", "rgb")
+
 #registering S3 method
 S3method(print, population)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 The pheno2geno package
 ======================
-Pheno2geno is an R package to create genetic maps out of phenotype expression data. 
-Currently supported breeding schemes are: Recombinant Inbred Lines (RIL), F2 and 
-backcross (BC). The master branch is the current stable version and is tagged. The 
+Pheno2geno is an R package to create genetic maps out of phenotype expression data.
+Currently supported breeding schemes are: Recombinant Inbred Lines (RIL), F2 and
+backcross (BC). The master branch is the current stable version and is tagged. The
 master branch can be installed into R, development branches may contain errors.
 
 Dependencies
 ------------
-+ R software environment from [www.r-project.org](http://www.r-project.org/ "www.r-project.org")
-+ qtl package from [www.rqtl.org](http://www.rqtl.org "www.rqtl.org") also available on [CRAN](http://cran.r-project.org/web/packages/qtl/index.html "http://cran.r-project.org/web/packages/qtl/index.html")
-+ mixtools package available on [CRAN](http://cran.r-project.org/web/packages/mixtools/index.html "http://cran.r-project.org/web/packages/mixtools/index.html")
++ R software environment from [www.r-project.org](https://www.r-project.org/ "www.r-project.org")
++ qtl package from [www.rqtl.org](http://www.rqtl.org "www.rqtl.org")
+also available on [CRAN](https://cran.r-project.org/package=qtl "https://cran.r-project.org/package=qtl")
++ mixtools package available on [CRAN](https://cran.r-project.org/package=mixtools "https://cran.r-project.org/package=mixtools")
 
 Optional:
 RankProd package from [www.bioconductor.org](http://www.bioconductor.org/packages/release/bioc/html/RankProd.html "www.bioconductor.org")
@@ -89,6 +90,6 @@ merchantability or fitness for a particular purpose.  See the GNU
 General Public License, version 3, for more details.
 
 A copy of the GNU General Public License, version 3, is available
-at [http://www.r-project.org/Licenses/GPL-3](http://www.r-project.org/Licenses/GPL-3 "GPL-3 Licence")
+at [https://www.r-project.org/Licenses/GPL-3](https://www.r-project.org/Licenses/GPL-3 "GPL-3 Licence")
 
 Copyright (c) 2010-2012 GBIC - Danny Arends, Konrad Zych, Ritsert C. Jansen

--- a/man/changeChromNumber.rd
+++ b/man/changeChromNumber.rd
@@ -10,9 +10,9 @@
 }
 
 \usage{
-	reduceChromosomesNumber(cross, numberOfChromosomes, verbose=FALSE)
-	removeChromosomes(cross, chromosomesToBeRmv, verbose=FALSE)
-	removeTooSmallChromosomes(cross, minNrOfMarkers, verbose=FALSE)
+    reduceChromosomesNumber(cross, numberOfChromosomes, verbose=FALSE)
+    removeChromosomes(cross, chromosomesToBeRmv, verbose=FALSE)
+    removeTooSmallChromosomes(cross, minNrOfMarkers, verbose=FALSE)
 }
 
 \arguments{
@@ -28,36 +28,36 @@
 }
 
 \details{
-There are three functions in pheno2geno to allow the user to manually reduce number of resulting chromosomes. 
+There are three functions in pheno2geno to allow the user to manually reduce number of resulting chromosomes.
 
 \emph{reduceChromosomesNumber}
-This functions removes all chromosomes from the cross object excluding chromosome 1 to numberOfChromosomes. It depends on the ordering 
-of chromosomes inside the cross object (which is based on the length of the chromosomes). 
+This functions removes all chromosomes from the cross object excluding chromosome 1 to numberOfChromosomes. It depends on the ordering
+of chromosomes inside the cross object (which is based on the length of the chromosomes).
 
 \emph{ removeChromosomes}
-This function removes chromosomes from the cross object by name. Because of this it does not depend on the 
+This function removes chromosomes from the cross object by name. Because of this it does not depend on the
 ordering of the chromosomes inside the cross object.
 
 \emph{ removeTooSmallChromosomes}
-This function is used to clean a cross object after using \code{\link{formLinkageGroups}}. FormLinkageGroups can 
-introduce small chromosomes as artifacts. These linkage groups consist of only a few markers with poor quality 
+This function is used to clean a cross object after using \code{\link{formLinkageGroups}}. FormLinkageGroups can
+introduce small chromosomes as artifacts. These linkage groups consist of only a few markers with poor quality
 and should be removed from the cross object.
 }
 
 \author{
-	Konrad Zych \email{k.zych@rug.nl}, Danny Arends \email{Danny.Arends@gmail.com}
-	Maintainer: Konrad Zych \email{k.zych@rug.nl}
+    Konrad Zych \email{k.zych@rug.nl}, Danny Arends \email{Danny.Arends@gmail.com}
+    Maintainer: Konrad Zych \email{k.zych@rug.nl}
 }
 
 \examples{
-	data(testCross)
-	plot.rf(testCross, main="riself generate.biomarkers example")
-	cross_ <- reduceChromosomesNumber(testCross,5,verb=TRUE)
-	plot.rf(cross_, main="Leaving only 5 chromosomes")
-	cross_ <- removeChromosomes(testCross,1,verb=TRUE)
-	plot.rf(cross_, main="Removing chromosome 1")
-	cross_ <- removeTooSmallChromosomes(testCross,5,verb=TRUE)
-	plot.rf(cross_, main="Leaving only chromosomes with more than 5 markers")
+    data(testCross)
+    plotRF(testCross, main="riself generate.biomarkers example")
+    cross_ <- reduceChromosomesNumber(testCross,5,verb=TRUE)
+    plotRF(cross_, main="Leaving only 5 chromosomes")
+    cross_ <- removeChromosomes(testCross,1,verb=TRUE)
+    plotRF(cross_, main="Removing chromosome 1")
+    cross_ <- removeTooSmallChromosomes(testCross,5,verb=TRUE)
+    plotRF(cross_, main="Leaving only chromosomes with more than 5 markers")
 }
 
 \seealso{


### PR DESCRIPTION
Due to a change in [CRAN](https://cran.r-project.org) submissions, I'm going to need to delete `plot.rf` (and similarly named functions) from [R/qtl](https:rqtl.org). `plotRF` can be used instead.

Needed to change one `man/*.rd` file.

But made a few additional changes to deal with `R CMD check` warnings/notes:

- Import `grDevices::rgb()` in `NAMESPACE` file

- Fixed some URLs in the `README`

- changed version and date